### PR TITLE
Make close thread safe

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -83,7 +83,7 @@ func (c *Conn) Write(b []byte) (n int, err error) {
 // close error, subsequent and concurrent calls will return nil.
 // This method is thread-safe.
 func (c *Conn) Close() error {
-	var err error = nil
+	var err error
 	c.closeOnce.Do(func() {
 		if c.done != nil {
 			c.done()


### PR DESCRIPTION
1. Ensure we only close the connection once. Especially, don't call the done function multiple times and/or concurrently.
2. Call WriteControl instead of WriteMessage in Close. WriteControl is thread-safe, WriteMessage isn't.

Also, this sets a 100ms deadline on gracefully closing connections.