### PR TITLE
close connections we fail to dial

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -28,6 +28,7 @@ func (d *dialer) DialContext(ctx context.Context, raddr ma.Multiaddr) (tpt.Conn,
 
 	mnc, err := manet.WrapNetConn(NewConn(wscon, nil))
 	if err != nil {
+		wscon.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
The previous commit did this for connections we accept but I forgot to do this
for dialed connections.