### PR TITLE
gx: update go-multihash

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.6.2: QmUE6HHybkvTDUkP6gHx41XNHsyZDwxCmxiD2fJABsg9eZ
+1.6.3: Qmf94orsHzPHawEm1WjS7zdpV69YDvQvbwBThTdMWoHS7F

--- a/package.json
+++ b/package.json
@@ -9,21 +9,21 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmX3U3YXCQ6UYBxq2LVWF8dARS1hPUTEYLrSx654Qyxyw6",
+      "hash": "QmSGL5Uoa6gKHgBBwQG8u1CWKUC8ZnwaZiLgFVTFBR2bxr",
       "name": "go-multiaddr-net",
-      "version": "1.5.5"
+      "version": "1.5.6"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmZQa5J7j7kd44GGC4aKX8J9JGGzCMqwGzcEFqGV1YD57A",
+      "hash": "QmUfnfCzL17Lfft4NtZZGGU34PP72xgecFVfusYt6WNwYx",
       "name": "mafmt",
-      "version": "1.2.3"
+      "version": "1.2.4"
     },
     {
       "author": "whyrusleeping",
-      "hash": "Qme2XMfKbWzzYd92YvA1qnFMe3pGDR86j5BcFtx4PwdRvr",
+      "hash": "QmQGRkVSA5vTXt9WpJ6nBGnrvq9zRNsfjoNPq8uQrhnBoq",
       "name": "go-libp2p-transport",
-      "version": "2.2.9"
+      "version": "2.2.10"
     },
     {
       "author": "gorilla",
@@ -33,9 +33,9 @@
     },
     {
       "author": "multiformats",
-      "hash": "QmXY77cVe7rVRQXZZQRioukUM7aRW3BTcAgJe12MCtb3Ji",
+      "hash": "QmW8s4zTsUoX1Q6CeYxVKPyqSKbF7H1YDUyTostBtZ8DaG",
       "name": "go-multiaddr",
-      "version": "1.2.4"
+      "version": "1.2.5"
     }
   ],
   "gxVersion": "0.4.0",
@@ -43,6 +43,6 @@
   "license": "MIT",
   "name": "go-ws-transport",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.6.2"
+  "version": "1.6.3"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-peer/pull/20
- https://github.com/libp2p/go-libp2p-secio/pull/23
- https://github.com/multiformats/go-multiaddr/pull/61
- https://github.com/multiformats/go-multiaddr-net/pull/33
- https://github.com/whyrusleeping/iptb/pull/37
- https://github.com/whyrusleeping/mafmt/pull/7
- https://github.com/libp2p/go-libp2p-peerstore/pull/18
- https://github.com/ipfs/go-ipfs-util/pull/6
- https://github.com/libp2p/go-libp2p-transport/pull/25
- https://github.com/libp2p/go-peerstream/pull/19
- https://github.com/libp2p/go-libp2p-loggables/pull/14
- https://github.com/libp2p/go-tcp-transport/pull/17
- https://github.com/libp2p/go-maddr-filter/pull/4


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace