### PR TITLE
Added wss dialing

### DIFF
--- a/addrs.go
+++ b/addrs.go
@@ -64,10 +64,17 @@ func ParseWebsocketNetAddr(a net.Addr) (ma.Multiaddr, error) {
 }
 
 func parseMultiaddr(a ma.Multiaddr) (string, error) {
-	_, host, err := manet.DialArgs(a)
+	p := a.Protocols()
+	host, err := a.ValueForProtocol(p[0].Code)
 	if err != nil {
 		return "", err
 	}
-
-	return "ws://" + host, nil
+	if p[0].Code == ma.P_IP6 {
+		host = "[" + host + "]"
+	}
+	port, err := a.ValueForProtocol(ma.P_TCP)
+	if err != nil {
+		return "", err
+	}
+	return p[2].Name + "://" + host + ":" + port, nil
 }

--- a/addrs_test.go
+++ b/addrs_test.go
@@ -20,6 +20,19 @@ func TestMultiaddrParsing(t *testing.T) {
 	if wsaddr != "ws://127.0.0.1:5555" {
 		t.Fatalf("expected ws://127.0.0.1:5555, got %s", wsaddr)
 	}
+
+	addr, err = ma.NewMultiaddr("/dnsaddr/example.com/tcp/5555/wss")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wsaddr, err = parseMultiaddr(addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wsaddr != "wss://example.com:5555" {
+		t.Fatalf("expected wss://example.com:5555, got %s", wsaddr)
+	}
 }
 
 type httpAddr struct {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/libp2p/go-libp2p-testing v0.0.3
 	github.com/libp2p/go-libp2p-transport-upgrader v0.1.1
 	github.com/multiformats/go-multiaddr v0.0.4
+	github.com/multiformats/go-multiaddr-fmt v0.0.1
 	github.com/multiformats/go-multiaddr-net v0.0.1
 	github.com/whyrusleeping/mafmt v1.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,10 @@ github.com/multiformats/go-multiaddr v0.0.4 h1:WgMSI84/eRLdbptXMkMWDXPjPq7SPLIgG
 github.com/multiformats/go-multiaddr v0.0.4/go.mod h1:xKVEak1K9cS1VdmPZW3LSIb6lgmoS58qz/pzqmAxV44=
 github.com/multiformats/go-multiaddr-dns v0.0.1 h1:jQt9c6tDSdQLIlBo4tXYx7QUHCPjxsB1zXcag/2S7zc=
 github.com/multiformats/go-multiaddr-dns v0.0.1/go.mod h1:9kWcqw/Pj6FwxAwW38n/9403szc57zJPs45fmnznu3Q=
+github.com/multiformats/go-multiaddr-dns v0.0.2 h1:/Bbsgsy3R6e3jf2qBahzNHzww6usYaZ0NhNH3sqdFS8=
+github.com/multiformats/go-multiaddr-dns v0.0.2/go.mod h1:9kWcqw/Pj6FwxAwW38n/9403szc57zJPs45fmnznu3Q=
+github.com/multiformats/go-multiaddr-fmt v0.0.1 h1:5YjeOIzbX8OTKVaN72aOzGIYW7PnrZrnkDyOfAWRSMA=
+github.com/multiformats/go-multiaddr-fmt v0.0.1/go.mod h1:aBYjqL4T/7j4Qx+R73XSv/8JsgnRFlf0w2KGLCmXl3Q=
 github.com/multiformats/go-multiaddr-net v0.0.1 h1:76O59E3FavvHqNg7jvzWzsPSW5JSi/ek0E4eiDVbg9g=
 github.com/multiformats/go-multiaddr-net v0.0.1/go.mod h1:nw6HSxNmCIQH27XPGBuX+d1tnvM7ihcFwHMSstNAVUU=
 github.com/multiformats/go-multibase v0.0.1/go.mod h1:bja2MqRZ3ggyXtZSEDKpl0uO/gviWFaSteVbWT51qgs=

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -21,6 +21,10 @@ func TestCanDial(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	addrWss, err := ma.NewMultiaddr("/dnsaddr/example.com/tcp/5555/wss")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	addrTCP, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/5555")
 	if err != nil {
@@ -29,10 +33,14 @@ func TestCanDial(t *testing.T) {
 
 	d := &WebsocketTransport{}
 	matchTrue := d.CanDial(addrWs)
+	matchTrueWss := d.CanDial(addrWss)
 	matchFalse := d.CanDial(addrTCP)
 
 	if !matchTrue {
 		t.Fatal("expected to match websocket maddr, but did not")
+	}
+	if !matchTrueWss {
+		t.Fatal("expected to match websocket+tls maddr, but did not")
 	}
 
 	if matchFalse {
@@ -51,6 +59,20 @@ func TestWebsocketTransport(t *testing.T) {
 	})
 
 	zero := "/ip4/127.0.0.1/tcp/0/ws"
+	ttransport.SubtestTransport(t, ta, tb, zero, "peerA")
+}
+
+func TestWebsocketTransport6(t *testing.T) {
+	ta := New(&tptu.Upgrader{
+		Secure: insecure.New("peerA"),
+		Muxer:  new(mplex.Transport),
+	})
+	tb := New(&tptu.Upgrader{
+		Secure: insecure.New("peerB"),
+		Muxer:  new(mplex.Transport),
+	})
+
+	zero := "/ip6/::1/tcp/0/ws"
 	ttransport.SubtestTransport(t, ta, tb, zero, "peerA")
 }
 

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -3,10 +3,15 @@ package websocket
 import (
 	"bytes"
 	"context"
+	//"crypto/x509"
 	"io"
 	"io/ioutil"
 	"testing"
 	"testing/iotest"
+	/*"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+*/
 
 	"github.com/libp2p/go-libp2p-core/sec/insecure"
 
@@ -21,7 +26,7 @@ func TestCanDial(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	addrWss, err := ma.NewMultiaddr("/dnsaddr/example.com/tcp/5555/wss")
+	addrWss, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/5555/wss")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,3 +221,59 @@ func TestWriteZero(t *testing.T) {
 		t.Errorf("expected EOF, got err: %s", err)
 	}
 }
+/*
+func TestWebsocketSecureComplete(t *testing.T) {
+	var cert *[]byte
+
+	cert, _ = &CreateCertificate()
+
+	listen, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/0/ws")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tpt := &WebsocketTransport{}
+	l, err := tpt.maListen(zero)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	fmt.Printf("%+v\n", l)
+
+	msg := []byte("HELLO WORLD")
+
+	go func() {
+		c, err := tpt.maDial(context.Background(), l.Multiaddr())
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		_, err = c.Write(msg)
+		if err != nil {
+			t.Error(err)
+		}
+		err = c.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}()
+
+	c, err := l.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	obr := iotest.OneByteReader(c)
+
+	out, err := ioutil.ReadAll(obr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(out, msg) {
+		t.Fatal("got wrong message", out, msg)
+	}
+}
+*/


### PR DESCRIPTION
This pr is a duplicate of #15 because it seems dead.
~~I chosed to only allow connection from dnsaddr (and dns4 and dns6) because wss is for browser and bypass mixed content error, so I recreated this so users will not get confused by working with go-ipfs and not in browser.~~
*That require an useless work and complexification of libp2p and libp2p-swarm so that was aborted.*

~~Also certificates came from system and is currently is only avaible on *nix due to a bug in golang's crypto/x509 library. The code need no change when the bug will be fixed to be windows compatible (just recompile). So on windows certificates will not be loaded and tls connection will be made even if certificate is wrong.~~
*That not a bug anymore because this fonctionality isn't anymore.*
## To do :
- [X] Implementation
- [ ] Add some test
  - [X] Parsing
  - [ ] Connection
- [ ] Test in real condition
  - [ ] libp2p
  - [ ] ipfs
- [ ] Add a small docs about reverse proxy
## Fix :
- [x] Fix the bug disabling wss when SSL certificate is not avaible by disabling SSL verification in this case.
- [ ] ~~Fix the bug making dns4 and dns6 like dnsaddr (currently its ignoring 4 and 6 and just taking the host)~~
## Potential future upgrade :
- Verify tls certificate of connection. (useless for security but good for minor compatibility with js-libp2p)
- Allow listen by generating a random certificate. (useless and will create some fake hope by browser peer and slow them down in their discovery of the network, only usefull with next point)
- Generate an TLS certificate for listening by derivating the libp2p private key with `websocket-secure` or wss protocol code and the host to have a constant one. (doesn't add more config for user, allow to **not** use a reverse proxy but still require manual approval of certificate)