### PR TITLE
Update go.mod to require Go 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,4 @@ require (
 	github.com/whyrusleeping/go-logging v0.0.1 // indirect
 )
 
-go 1.12
+go 1.13


### PR DESCRIPTION
https://github.com/libp2p/go-ws-transport/pull/68 uses the new `CopyBytesToGo` and `CopyBytesToJS` functions, which are only available in Go 1.13.