### PR TITLE
add support for listening on /wss addresses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/libp2p/go-libp2p-transport-upgrader v0.7.0
 	github.com/multiformats/go-multiaddr v0.4.1
 	github.com/multiformats/go-multiaddr-fmt v0.1.0
+	github.com/stretchr/testify v1.7.0
 )
 
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,10 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/libp2p/go-buffer-pool v0.0.2 h1:QNK2iAFa8gjAe1SPz6mHSMuCcjs+X1wlHzeOSqcmlfs=
 github.com/libp2p/go-buffer-pool v0.0.2/go.mod h1:MvaB6xw5vOrDl8rYZGLFdKAuk/hRoRZd1Vi32+RXyFM=
@@ -249,6 +251,7 @@ google.golang.org/grpc v1.28.1/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKa
 google.golang.org/grpc v1.31.1 h1:SfXqXS5hkufcdZ/mHtYCh53P2b+92WQq/DZcKLgsFRs=
 google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/src-d/go-cli.v0 v0.0.0-20181105080154-d492247bbc0d/go.mod h1:z+K8VcOYVYcSwSjGebuDL6176A1XskgbtNl64NSg+n8=

--- a/listener.go
+++ b/listener.go
@@ -17,6 +17,19 @@ type listener struct {
 	incoming chan *Conn
 }
 
+func newListener(l net.Listener) (*listener, error) {
+	laddr, err := manet.FromNetAddr(l.Addr())
+	if err != nil {
+		return nil, err
+	}
+	return &listener{
+		Listener: l,
+		laddr:    laddr.Encapsulate(wsma),
+		incoming: make(chan *Conn),
+		closed:   make(chan struct{}),
+	}, nil
+}
+
 func (l *listener) serve() {
 	defer close(l.closed)
 	_ = http.Serve(l.Listener, l)

--- a/websocket.go
+++ b/websocket.go
@@ -4,23 +4,22 @@ package websocket
 import (
 	"context"
 	"crypto/tls"
-	"net"
 	"net/http"
+	"time"
 
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/transport"
 
-	ws "github.com/gorilla/websocket"
 	ma "github.com/multiformats/go-multiaddr"
 	mafmt "github.com/multiformats/go-multiaddr-fmt"
 	manet "github.com/multiformats/go-multiaddr/net"
+
+	ws "github.com/gorilla/websocket"
 )
 
 // WsFmt is multiaddr formatter for WsProtocol
 var WsFmt = mafmt.And(mafmt.TCP, mafmt.Base(ma.P_WS))
-
-var wsma = ma.StringCast("/ws")
 
 // This is _not_ WsFmt because we want the transport to stick to dialing fully
 // resolved addresses.
@@ -54,12 +53,21 @@ func WithTLSClientConfig(c *tls.Config) Option {
 	}
 }
 
+// WithTLSConfig sets a TLS configuration for the WebSocket listener.
+func WithTLSConfig(conf *tls.Config) Option {
+	return func(t *WebsocketTransport) error {
+		t.tlsConf = conf
+		return nil
+	}
+}
+
 // WebsocketTransport is the actual go-libp2p transport
 type WebsocketTransport struct {
 	upgrader transport.Upgrader
 	rcmgr    network.ResourceManager
 
 	tlsClientConf *tls.Config
+	tlsConf       *tls.Config
 }
 
 var _ transport.Transport = (*WebsocketTransport)(nil)
@@ -110,13 +118,18 @@ func (t *WebsocketTransport) maDial(ctx context.Context, raddr ma.Multiaddr) (ma
 	if err != nil {
 		return nil, err
 	}
+	isWss := wsurl.Scheme == "wss"
+	dialer := ws.Dialer{HandshakeTimeout: 30 * time.Second}
+	if isWss {
+		dialer.TLSClientConfig = t.tlsClientConf
 
-	wscon, _, err := ws.DefaultDialer.Dial(wsurl.String(), nil)
+	}
+	wscon, _, err := dialer.DialContext(ctx, wsurl.String(), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	mnc, err := manet.WrapNetConn(NewConn(wscon, wsurl.Scheme == "wss"))
+	mnc, err := manet.WrapNetConn(NewConn(wscon, isWss))
 	if err != nil {
 		wscon.Close()
 		return nil, err
@@ -125,17 +138,8 @@ func (t *WebsocketTransport) maDial(ctx context.Context, raddr ma.Multiaddr) (ma
 }
 
 func (t *WebsocketTransport) maListen(a ma.Multiaddr) (manet.Listener, error) {
-	lnet, lnaddr, err := manet.DialArgs(a)
+	l, err := newListener(a, t.tlsConf)
 	if err != nil {
-		return nil, err
-	}
-	nl, err := net.Listen(lnet, lnaddr)
-	if err != nil {
-		return nil, err
-	}
-	l, err := newListener(nl)
-	if err != nil {
-		nl.Close()
 		return nil, err
 	}
 	go l.serve()

--- a/websocket.go
+++ b/websocket.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
-	"net/url"
 
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -128,24 +127,15 @@ func (t *WebsocketTransport) maListen(a ma.Multiaddr) (manet.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	nl, err := net.Listen(lnet, lnaddr)
 	if err != nil {
 		return nil, err
 	}
-
-	u, err := url.Parse("http://" + nl.Addr().String())
+	malist, err := t.wrapListener(nl)
 	if err != nil {
 		nl.Close()
 		return nil, err
 	}
-
-	malist, err := t.wrapListener(nl, u)
-	if err != nil {
-		nl.Close()
-		return nil, err
-	}
-
 	go malist.serve()
 
 	return malist, nil
@@ -159,7 +149,7 @@ func (t *WebsocketTransport) Listen(a ma.Multiaddr) (transport.Listener, error) 
 	return t.upgrader.UpgradeListener(t, malist), nil
 }
 
-func (t *WebsocketTransport) wrapListener(l net.Listener, origin *url.URL) (*listener, error) {
+func (t *WebsocketTransport) wrapListener(l net.Listener) (*listener, error) {
 	laddr, err := manet.FromNetAddr(l.Addr())
 	if err != nil {
 		return nil, err

--- a/websocket.go
+++ b/websocket.go
@@ -133,14 +133,13 @@ func (t *WebsocketTransport) maListen(a ma.Multiaddr) (manet.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	malist, err := t.wrapListener(nl)
+	l, err := newListener(nl)
 	if err != nil {
 		nl.Close()
 		return nil, err
 	}
-	go malist.serve()
-
-	return malist, nil
+	go l.serve()
+	return l, nil
 }
 
 func (t *WebsocketTransport) Listen(a ma.Multiaddr) (transport.Listener, error) {
@@ -149,17 +148,4 @@ func (t *WebsocketTransport) Listen(a ma.Multiaddr) (transport.Listener, error) 
 		return nil, err
 	}
 	return t.upgrader.UpgradeListener(t, malist), nil
-}
-
-func (t *WebsocketTransport) wrapListener(l net.Listener) (*listener, error) {
-	laddr, err := manet.FromNetAddr(l.Addr())
-	if err != nil {
-		return nil, err
-	}
-	return &listener{
-		laddr:    laddr.Encapsulate(wsma),
-		Listener: l,
-		incoming: make(chan *Conn),
-		closed:   make(chan struct{}),
-	}, nil
 }

--- a/websocket.go
+++ b/websocket.go
@@ -20,6 +20,8 @@ import (
 // WsFmt is multiaddr formatter for WsProtocol
 var WsFmt = mafmt.And(mafmt.TCP, mafmt.Base(ma.P_WS))
 
+var wsma = ma.StringCast("/ws")
+
 // This is _not_ WsFmt because we want the transport to stick to dialing fully
 // resolved addresses.
 var dialMatcher = mafmt.And(mafmt.IP, mafmt.Base(ma.P_TCP), mafmt.Or(mafmt.Base(ma.P_WS), mafmt.Base(ma.P_WSS)))
@@ -154,14 +156,8 @@ func (t *WebsocketTransport) wrapListener(l net.Listener) (*listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	wsma, err := ma.NewMultiaddr("/ws")
-	if err != nil {
-		return nil, err
-	}
-	laddr = laddr.Encapsulate(wsma)
-
 	return &listener{
-		laddr:    laddr,
+		laddr:    laddr.Encapsulate(wsma),
 		Listener: l,
 		incoming: make(chan *Conn),
 		closed:   make(chan struct{}),


### PR DESCRIPTION
Fixes #70.

Listening on `/wss` addresses is only enabled when a TLS config is passed to the transport on initialization (using the `WithTLSConfig` option).