### PR TITLE
don't resolve dns addresses for Listener.Multiaddr

### DIFF
--- a/addrs_test.go
+++ b/addrs_test.go
@@ -4,6 +4,8 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -64,4 +66,16 @@ func TestConvertWebsocketMultiaddrToNetAddr(t *testing.T) {
 	if wsaddr.Network() != "websocket" {
 		t.Fatalf("expected network: \"websocket\", got \"%s\"", wsaddr.Network())
 	}
+}
+
+func TestListeningOnDNSAddr(t *testing.T) {
+	ln, err := newListener(ma.StringCast("/dns/localhost/tcp/0/ws"), nil)
+	require.NoError(t, err)
+	addr := ln.Multiaddr()
+	first, rest := ma.SplitFirst(addr)
+	require.Equal(t, first.Protocol().Code, ma.P_DNS)
+	require.Equal(t, first.Value(), "localhost")
+	next, _ := ma.SplitFirst(rest)
+	require.Equal(t, next.Protocol().Code, ma.P_TCP)
+	require.NotEqual(t, next.Value(), "0")
 }

--- a/listener.go
+++ b/listener.go
@@ -47,6 +47,13 @@ func newListener(a ma.Multiaddr, tlsConf *tls.Config) (*listener, error) {
 	if err != nil {
 		return nil, err
 	}
+	first, _ := ma.SplitFirst(a)
+	// Don't resolve dns addresses.
+	// We want to be able to announce domain names, so the peer can validate the TLS certificate.
+	if c := first.Protocol().Code; c == ma.P_DNS || c == ma.P_DNS4 || c == ma.P_DNS6 || c == ma.P_DNSADDR {
+		_, last := ma.SplitFirst(laddr)
+		laddr = first.Encapsulate(last)
+	}
 
 	ln := &listener{
 		nl:       nl,


### PR DESCRIPTION
We need to announce `/dns` addresses to the network, so (browser) nodes can actually verify the certificate we're serving them. In order to do that, they need our domain name, not our IP address.